### PR TITLE
Small additions

### DIFF
--- a/src/com/ssplugins/shadow3/entity/Keyword.java
+++ b/src/com/ssplugins/shadow3/entity/Keyword.java
@@ -75,7 +75,7 @@ public class Keyword extends ShadowEntity {
             }
             parent = parent.getParent();
         }
-        return fallback.findKeyword(name).orElseThrow(ShadowCodeException.noDef(getLine(), getLine().firstToken().getIndex(), "No definition found for keyword: " + name));
+        return fallback.findKeyword(name).orElseThrow(ShadowCodeException.noDef(getLine(), argumentIndex(-1), "No definition found for keyword: " + name));
     }
     
     public static Schema<Keyword> inlineOnly() {

--- a/src/com/ssplugins/shadow3/execute/Stepper.java
+++ b/src/com/ssplugins/shadow3/execute/Stepper.java
@@ -58,6 +58,10 @@ public class Stepper {
         iterator = content.iterator();
     }
     
+    public void continueToEnd() {
+        while (iterator.hasNext()) iterator.next();
+    }
+    
     public void breakBlock() {
         run = false;
     }

--- a/src/com/ssplugins/shadow3/parsing/ShadowParser.java
+++ b/src/com/ssplugins/shadow3/parsing/ShadowParser.java
@@ -98,7 +98,7 @@ public class ShadowParser {
         reader.consume();
         List<ShadowSection> sections = reader.readTo(end, raw);
         sections.remove(sections.size() - 1);
-        return new Compound(reader.getLine(), sections, reader.getParent().getEffectiveContext());
+        return new Compound(reader.getLine(), sections, reader.getParent());
     }
     
     public Shadow parse(File file) {

--- a/src/com/ssplugins/shadow3/parsing/TokenReader.java
+++ b/src/com/ssplugins/shadow3/parsing/TokenReader.java
@@ -1,6 +1,5 @@
 package com.ssplugins.shadow3.parsing;
 
-import com.ssplugins.shadow3.api.ShadowContext;
 import com.ssplugins.shadow3.entity.ShadowEntity;
 import com.ssplugins.shadow3.exception.ShadowParseError;
 import com.ssplugins.shadow3.section.Compound;
@@ -87,20 +86,20 @@ public class TokenReader extends Reader<Token> {
         return sections;
     }
     
-    public Compound readCompoundValue(TokenType type, ShadowContext context) {
-        return readCompoundValue(type, null, context);
+    public Compound readCompoundValue(TokenType type, ShadowEntity entity) {
+        return readCompoundValue(type, null, entity);
     }
     
-    public Compound readCompoundValue(TokenType type, String raw, ShadowContext context) {
+    public Compound readCompoundValue(TokenType type, String raw, ShadowEntity entity) {
         List<ShadowSection> sections = readTo(type, raw);
         sections.remove(sections.size() - 1);
-        return new Compound(line, sections, context);
+        return new Compound(line, sections, entity);
     }
     
-    public ShadowSection readCompoundValue(Predicate<Token> predicate, String expecting, ShadowContext context) {
+    public ShadowSection readCompoundValue(Predicate<Token> predicate, String expecting, ShadowEntity entity) {
         List<ShadowSection> sections = readTo(predicate, expecting, false);
         if (sections.size() == 1) return sections.get(0);
-        return new Compound(line, sections, context);
+        return new Compound(line, sections, entity);
     }
     
     public ShadowSection readAs(TokenType type) {

--- a/src/com/ssplugins/shadow3/section/Compound.java
+++ b/src/com/ssplugins/shadow3/section/Compound.java
@@ -1,6 +1,6 @@
 package com.ssplugins.shadow3.section;
 
-import com.ssplugins.shadow3.api.ShadowContext;
+import com.ssplugins.shadow3.entity.ShadowEntity;
 import com.ssplugins.shadow3.exception.ShadowParseError;
 import com.ssplugins.shadow3.execute.Scope;
 import com.ssplugins.shadow3.parsing.Token;
@@ -20,7 +20,7 @@ public class Compound extends ShadowSection {
     private boolean computed = false;
     private Object value;
     
-    public Compound(TokenLine line, List<ShadowSection> sections, ShadowContext context) {
+    public Compound(TokenLine line, List<ShadowSection> sections, ShadowEntity parent) {
         super(line);
         this.setTokens(sections.stream().map(ShadowSection::getTokens).flatMap(Stream::of).toArray(Token[]::new));
         
@@ -31,11 +31,11 @@ public class Compound extends ShadowSection {
             if (section instanceof Operator) {
                 Operator operator = (Operator) section;
                 if (opTree.expectingUnary()) {
-                    operator.lookupUnary(context);
+                    operator.lookupUnary(parent);
                     opTree.insert(new UnaryOpNode(operator), section.getPrimaryToken());
                 }
                 else {
-                    operator.lookup(context);
+                    operator.lookup(parent);
                     opTree.insert(new OpNode(operator), section.getPrimaryToken());
                 }
             }

--- a/src/com/ssplugins/shadow3/test/testy.shd
+++ b/src/com/ssplugins/shadow3/test/testy.shd
@@ -1,6 +1,24 @@
 main {
+    set options [array [new 3] (0 = "Option 1") (1 = "Option 2") (2 = "Option 3")]
+    set pick [exec select("Testing options:", options)]
+    if (pick == -1) {
+        print "Exiting..."
+        exit
+    }
+    print "You picked: " (pick + 1) " -> " [array options [get pick]]
+}
 
-    if ("foobar" => [contains "bar"]) :: print "yes"
-    else :: print "no"
-
+define select -> prompt, options {
+    print prompt
+    foreach [count [len options]] -> i {
+        print (i + 1) ") " [array options [get i]]
+    }
+    while true {
+        set pick [input]
+        if [empty pick] :: continue
+        set pick [int pick]
+        if (pick == -1) :: return (-1)
+        if (pick > 0 && pick <= [len options]) :: return (pick - 1)
+        print "Please select a valid option."
+    }
 }


### PR DESCRIPTION
- Added not operator !
- Added boolean operators && and ||
- Added "exit" keyword which terminates the program.
- Added "empty" keyword for the function of String#isEmpty
- Added conversion keywords str, int, double, float, long. (Others will be added in the future).
- Added "nothing" keyword to fill empty one-line blocks.
- Added loop control keywords "break" and "continue" to the following blocks: repeat, foreach, while.
- Added "while" block.

Fixes:
- Fixed context on define block.
- Error when definition for keyword cannot be found now shows correct index.
- Compounds now search the entire parent tree of contexts for definitions.